### PR TITLE
updated requirements to fix conflict between numpy and sklearn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ imbalanced-learn==0.11.0
 joblib==1.3.2
 lxml==4.9.3
 nltk==3.8.1
-numpy==1.24.4
+numpy==1.26.4
 olefile==0.46
 pdfminer.six==20191110
 Pillow==9.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ imbalanced-learn==0.11.0
 joblib==1.3.2
 lxml==4.9.3
 nltk==3.8.1
-numpy==1.26.1
+numpy==1.24.4
 olefile==0.46
 pdfminer.six==20191110
 Pillow==9.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,8 +43,8 @@ dev =
     ruff
 
 [options.package_data]
-mypkg =
-    *.pkl
+srt_ml =
+    binaries/*.pkl
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
The error

```
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```

occurs because a compiled extension (in scikit‑learn) was built against a different version of NumPy than the one we currently have installed. In this case, the extension expected a certain binary layout (with a data type size of 96) but found a different layout (size 88), causing a mismatch.

What we did to fix it was to change the NumPy version in our requirements. Our diff shows that we changed from:

```diff
-numpy==1.26.1
+numpy==1.24.4
```

By downgrading from NumPy 1.26.1 to 1.24.4, we ensured that the installed NumPy version matches what the compiled extensions expect. This resolved the binary incompatibility issue 